### PR TITLE
Replace indices with size in warp function

### DIFF
--- a/Chapter05/3_orb.jl
+++ b/Chapter05/3_orb.jl
@@ -6,7 +6,7 @@ img2 = Gray.(load("cat-3417184_640_watermarked.jpg"))
 # rotation img2 around the center
 rot = recenter(RotMatrix(5pi/6), [size(img2)...] .÷ 2)  # a rotation around the center
 tform = rot ∘ Translation(-50, -40)
-img2 = warp(img2, tform, indices(img2))
+img2 = warp(img2, tform, size(img2))
 
 orb_params = ORB(num_keypoints = 1000)
 

--- a/Chapter05/4_brisk.jl
+++ b/Chapter05/4_brisk.jl
@@ -6,7 +6,7 @@ img2 = Gray.(load("cat-3417184_640_watermarked.jpg"))
 # rotate img2 around the center and resize it
 rot = recenter(RotMatrix(5pi/6), [size(img2)...] .÷ 2)  # a rotation around the center
 tform = rot ∘ Translation(-50, -40)
-img2 = warp(img2, tform, indices(img2))
+img2 = warp(img2, tform, size(img2))
 img2 = imresize(img2, Int.(trunc.(size(img2) .* 0.7)))
 
 features_1 = Features(fastcorners(img1, 12, 0.35));

--- a/Chapter05/5_freak.jl
+++ b/Chapter05/5_freak.jl
@@ -6,7 +6,7 @@ img2 = Gray.(load("cat-3417184_640_watermarked.jpg"))
 # rotate img2 around the center and resize it
 rot = recenter(RotMatrix(5pi/6), [size(img2)...] .÷ 2) 
 tform = rot ∘ Translation(-50, -40)
-img2 = warp(img2, tform, indices(img2))
+img2 = warp(img2, tform, size(img2))
 img2 = imresize(img2, Int.(trunc.(size(img2) .* 0.7)))
 
 keypoints_1 = Keypoints(fastcorners(img1, 12, 0.35));


### PR DESCRIPTION
Indices no longer runs in newer versions of julia. Replacing it with `size` allows the warp function to run properly.